### PR TITLE
Added API routing template with 2 functions, 2 methods each

### DIFF
--- a/.funcignore
+++ b/.funcignore
@@ -1,0 +1,5 @@
+.git*
+.vscode
+local.settings.json
+test
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,135 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don’t work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Azure Functions artifacts
+bin
+obj
+appsettings.json
+local.settings.json
+
+# Azurite artifacts
+.python_packages
+
+# VS Code files
+.vscode

--- a/function_app.py
+++ b/function_app.py
@@ -1,0 +1,16 @@
+import azure.functions as func
+from functions.func_1.method_1 import blueprint_func_1_method_1
+from functions.func_1.method_2 import blueprint_func_1_method_2
+from functions.func_2.method_1 import blueprint_func_2_method_1
+from functions.func_2.method_2 import blueprint_func_2_method_2
+
+app = func.FunctionApp(
+    # http_auth_level=func.AuthLevel.FUNCTION
+    http_auth_level=func.AuthLevel.ANONYMOUS
+)
+
+app.register_functions(blueprint_func_1_method_1)
+app.register_functions(blueprint_func_1_method_2)
+
+app.register_functions(blueprint_func_2_method_1)
+app.register_functions(blueprint_func_2_method_2)

--- a/functions/func_1/method_1.py
+++ b/functions/func_1/method_1.py
@@ -1,0 +1,17 @@
+import json
+import azure.functions as func
+
+blueprint_func_1_method_1 = func.Blueprint()
+@blueprint_func_1_method_1.function_name(name='func_1_method_1')
+@blueprint_func_1_method_1.route(
+    route='func_1/method_1', methods=['GET']
+)
+
+def func_1_method_1(req: func.HttpRequest) -> func.HttpResponse:
+    resp = {"func_1": "method_1"}
+
+    return func.HttpResponse(
+        body=json.dumps(resp),
+        status_code=200,
+        mimetype="application/json"
+    )

--- a/functions/func_1/method_2.py
+++ b/functions/func_1/method_2.py
@@ -1,0 +1,17 @@
+import json
+import azure.functions as func
+
+blueprint_func_1_method_2 = func.Blueprint()
+@blueprint_func_1_method_2.function_name(name='func_1_method_2')
+@blueprint_func_1_method_2.route(
+    route='func_1/method_2', methods=['GET']
+)
+
+def func_1_method_2(req: func.HttpRequest) -> func.HttpResponse:
+    resp = {"func_1": "method_2"}
+
+    return func.HttpResponse(
+        body=json.dumps(resp),
+        status_code=200,
+        mimetype="application/json"
+    )

--- a/functions/func_2/method_1.py
+++ b/functions/func_2/method_1.py
@@ -1,0 +1,17 @@
+import json
+import azure.functions as func
+
+blueprint_func_2_method_1 = func.Blueprint()
+@blueprint_func_2_method_1.function_name(name='func_2_method_1')
+@blueprint_func_2_method_1.route(
+    route='func_2/method_1', methods=['GET']
+)
+
+def func_2_method_1(req: func.HttpRequest) -> func.HttpResponse:
+    resp = {"func_2": "method_1"}
+
+    return func.HttpResponse(
+        body=json.dumps(resp),
+        status_code=200,
+        mimetype="application/json"
+    )

--- a/functions/func_2/method_2.py
+++ b/functions/func_2/method_2.py
@@ -1,0 +1,17 @@
+import json
+import azure.functions as func
+
+blueprint_func_2_method_2 = func.Blueprint()
+@blueprint_func_2_method_2.function_name(name='func_2_method_2')
+@blueprint_func_2_method_2.route(
+    route='func_2/method_2', methods=['GET']
+)
+
+def func_2_method_2(req: func.HttpRequest) -> func.HttpResponse:
+    resp = {"func_2": "method_2"}
+
+    return func.HttpResponse(
+        body=json.dumps(resp),
+        status_code=200,
+        mimetype="application/json"
+    )

--- a/host.json
+++ b/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# DO NOT include azure-functions-worker in this file
+# The Python Worker is managed by Azure Functions platform
+# Manually managing azure-functions-worker may cause unexpected issues
+
+azure-functions

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Empty __init__.py file marks shared_code folder as a Python package


### PR DESCRIPTION
The routing template supports two dummy functions with two GET methods each.

func_1_method_1: [GET] http://localhost:7071/api/func_1/method_1
func_1_method_2: [GET] http://localhost:7071/api/func_1/method_2
func_2_method_1: [GET] http://localhost:7071/api/func_2/method_1
func_2_method_2: [GET] http://localhost:7071/api/func_2/method_2